### PR TITLE
Rack v3: Streams

### DIFF
--- a/lib/twirp.rb
+++ b/lib/twirp.rb
@@ -14,5 +14,6 @@
 require_relative 'twirp/version'
 require_relative 'twirp/error'
 require_relative 'twirp/service'
+require_relative 'twirp/stream'
 require_relative 'twirp/client'
 require_relative 'twirp/client_json'

--- a/lib/twirp/service.rb
+++ b/lib/twirp/service.rb
@@ -79,7 +79,7 @@ module Twirp
       end
 
       headers = env[:http_response_headers].merge('content-type' => env[:content_type])
-      stream = Stream.new(env) { |input| call_handler(input, env) }
+      stream = Stream.new(env) { |stream| call_handler(stream) }
 
       [200, headers, stream]
     rescue => e
@@ -137,16 +137,8 @@ module Twirp
     end
 
     # Call handler method and return a Protobuf Message or a Twirp::Error.
-    def call_handler(input, env)
-      out = @handler.send(env[:ruby_method], input, env)
-      case out
-      when env[:output_class], Twirp::Error
-        out
-      when Hash
-        env[:output_class].new(out)
-      else
-        Twirp::Error.internal("Handler method #{m} expected to return one of #{env[:output_class].name}, Hash or Twirp::Error, but returned #{out.class.name}.")
-      end
+    def call_handler(stream)
+      @handler.send(stream.env[:ruby_method], stream)
     end
   end
 end

--- a/lib/twirp/service.rb
+++ b/lib/twirp/service.rb
@@ -32,12 +32,21 @@ module Twirp
       # Rack response with a Twirp::Error
       def error_response(twerr)
         status = Twirp::ERROR_CODES_TO_HTTP_STATUS[twerr.code]
-        headers = {'Content-Type' => Encoding::JSON} # Twirp errors are always JSON, even if the request was protobuf
+        headers = {'content-type' => Encoding::JSON} # Twirp errors are always JSON, even if the request was protobuf
         resp_body = Encoding.encode_json(twerr.to_h)
         [status, headers, [resp_body]]
+      rescue => err
+        puts err
+        puts err.backtrace.first(5).join("\n")
+        exception_response(err)
       end
 
+      def exception_response(e)
+        twerr = Twirp::Error.internal_with(e)
+        error_response(twerr)
+      end
     end
+
 
     def initialize(handler)
       @handler = handler
@@ -60,50 +69,29 @@ module Twirp
 
     # Rack app handler.
     def call(rack_env)
-      begin
-        env = {}
-        bad_route = route_request(rack_env, env)
-        return error_response(bad_route, env) if bad_route
+      env = {}
+      bad_route = route_request(rack_env, env)
+      return self.class.error_response(bad_route) if bad_route
 
-        @before.each do |hook|
-          result = hook.call(rack_env, env)
-          return error_response(result, env) if result.is_a? Twirp::Error
-        end
-
-        output = call_handler(env)
-        return error_response(output, env) if output.is_a? Twirp::Error
-        return success_response(output, env)
-
-      rescue => e
-        raise e if self.class.raise_exceptions
-        begin
-          @exception_raised.each{|hook| hook.call(e, env) }
-        rescue => hook_e
-          e = hook_e
-        end
-
-        twerr = Twirp::Error.internal_with(e)
-        return error_response(twerr, env)
+      @before.each do |hook|
+        result = hook.call(rack_env, env)
+        return self.class.error_response(result) if result.is_a? Twirp::Error
       end
+
+      headers = env[:http_response_headers].merge('content-type' => env[:content_type])
+      stream = Stream.new(env) { |input| call_handler(input, env) }
+
+      [200, headers, stream]
+    rescue => e
+      begin
+        @exception_raised.each{|hook| hook.call(e, env) }
+      rescue => hook_e
+        e = hook_e
+      end
+
+      twerr = Twirp::Error.internal_with(e)
+      self.class.error_response(twerr)
     end
-
-    # Call the handler method with input attributes or protobuf object.
-    # Returns a proto object (response) or a Twirp::Error.
-    # Hooks are not called and exceptions are raised instead of being wrapped.
-    # This is useful for unit testing the handler. The env should include
-    # fake data that is used by the handler, replicating middleware and before hooks.
-    def call_rpc(rpc_method, input={}, env={})
-      base_env = self.class.rpcs[rpc_method.to_s]
-      return Twirp::Error.bad_route("Invalid rpc method #{rpc_method.to_s.inspect}") unless base_env
-
-      env = env.merge(base_env)
-      input = env[:input_class].new(input) if input.is_a? Hash
-      env[:input] = input
-      env[:content_type] ||= Encoding::PROTO
-      env[:http_response_headers] = {}
-      call_handler(env)
-    end
-
 
   private
 
@@ -135,20 +123,11 @@ module Twirp
       end
       env.merge!(base_env) # :rpc_method, :input_class, :output_class
 
-      input = nil
-      begin
-        body_str = rack_request.body.read
-        rack_request.body.rewind # allow other middleware to read again (https://github.com/arthurnn/twirp-ruby/issues/50)
-        input = Encoding.decode(body_str, env[:input_class], content_type)
-      rescue => e
-        error_msg = "Invalid request body for rpc method #{method_name.inspect} with Content-Type=#{content_type}"
-        if e.is_a?(Google::Protobuf::ParseError)
-          error_msg += ": #{e.message.strip}"
-        end
-        return route_err(:malformed, error_msg, rack_request)
+      m = env[:ruby_method]
+      if !@handler.respond_to?(m)
+        return Twirp::Error.unimplemented("Handler method #{m} is not implemented.")
       end
 
-      env[:input] = input
       env[:http_response_headers] = {}
       return
     end
@@ -157,15 +136,9 @@ module Twirp
       Twirp::Error.new code, msg, twirp_invalid_route: "#{req.request_method} #{req.path}"
     end
 
-
     # Call handler method and return a Protobuf Message or a Twirp::Error.
-    def call_handler(env)
-      m = env[:ruby_method]
-      if !@handler.respond_to?(m)
-        return Twirp::Error.unimplemented("Handler method #{m} is not implemented.")
-      end
-
-      out = @handler.send(m, env[:input], env)
+    def call_handler(input, env)
+      out = @handler.send(env[:ruby_method], input, env)
       case out
       when env[:output_class], Twirp::Error
         out
@@ -175,42 +148,5 @@ module Twirp
         Twirp::Error.internal("Handler method #{m} expected to return one of #{env[:output_class].name}, Hash or Twirp::Error, but returned #{out.class.name}.")
       end
     end
-
-    def success_response(output, env)
-      begin
-        env[:output] = output
-        @on_success.each{|hook| hook.call(env) }
-
-        headers = env[:http_response_headers].merge('Content-Type' => env[:content_type])
-        resp_body = Encoding.encode(output, env[:output_class], env[:content_type])
-        [200, headers, [resp_body]]
-
-      rescue => e
-        return exception_response(e, env)
-      end
-    end
-
-    def error_response(twerr, env)
-      begin
-        @on_error.each{|hook| hook.call(twerr, env) }
-        self.class.error_response(twerr)
-      rescue => e
-        return exception_response(e, env)
-      end
-    end
-
-    def exception_response(e, env)
-      raise e if self.class.raise_exceptions
-
-      begin
-        @exception_raised.each{|hook| hook.call(e, env) }
-      rescue => hook_e
-        e = hook_e
-      end
-
-      twerr = Twirp::Error.internal_with(e)
-      self.class.error_response(twerr)
-    end
-
   end
 end

--- a/lib/twirp/stream.rb
+++ b/lib/twirp/stream.rb
@@ -1,24 +1,49 @@
 
 module Twirp
   class Stream
+    attr_reader :env
+
     def initialize(env, &block)
       @env = env
       @block = block
+      @stream = nil
+    end
+
+    def read
+      Encoding.decode(
+        @stream.read,
+        @env[:input_class],
+        @env[:content_type],
+      )
+    end
+
+    def write(out)
+      result = case out
+      when @env[:output_class], Twirp::Error
+        out
+      when Hash
+        @env[:output_class].new(out)
+      else
+        Twirp::Error.internal("Handler method #{@env[:ruby_method]} expected to return one of #{@env[:output_class].name}, Hash or Twirp::Error, but returned #{out.class.name}.")
+      end
+
+      if result.is_a? Twirp::Error
+        @stream.write(Service.error_response(result)[2])
+      else
+        resp_body = Encoding.encode(result, @env[:output_class], @env[:content_type])
+        @stream.write(resp_body)
+      end
     end
 
     def call(stream)
-      input = Encoding.decode(stream.read, @env[:input_class], @env[:content_type])
-
-      result = @block.call(input)
-
-      if result.is_a? Twirp::Error
-        stream.write(Service.error_response(result)[2])
-      else
-        resp_body = Encoding.encode(result, @env[:output_class], @env[:content_type])
-        stream.write(resp_body)
-      end
+      @stream = stream
+      out = @block.call(self)
+      write(out) if out.is_a?(@env[:output_class]) || out.is_a?(Hash) || out.is_a?(Twirp::Error)
+    rescue => e
+      @stream.write(Service.exception_response(e))
     ensure
-      stream.close
+      @stream.close
+      @stream = nil
     end
   end
 end

--- a/lib/twirp/stream.rb
+++ b/lib/twirp/stream.rb
@@ -1,0 +1,24 @@
+
+module Twirp
+  class Stream
+    def initialize(env, &block)
+      @env = env
+      @block = block
+    end
+
+    def call(stream)
+      input = Encoding.decode(stream.read, @env[:input_class], @env[:content_type])
+
+      result = @block.call(input)
+
+      if result.is_a? Twirp::Error
+        stream.write(Service.error_response(result)[2])
+      else
+        resp_body = Encoding.encode(result, @env[:output_class], @env[:content_type])
+        stream.write(resp_body)
+      end
+    ensure
+      stream.close
+    end
+  end
+end


### PR DESCRIPTION
# What

This PR is a prototype that updates `twirp-ruby` to work with Rack v3 & streamed requests & responses. I've introduces a `Twirp::Stream` class that wraps the Rack stream to add input & output encoding.

# Issues

This list probably isn't complete but theres a few known issues with my changes:

- Along the way I removed the `@on_error` handlers to make the refactor simpler. They need to be reimplemented.
- `self.class`raise_exceptions` also needs to be reimplemented.
- The API of the Handler classes now take a `Twirp::Stream` & are expected to call `#read` & `#write`.
  - You can still return the result from the Handler & the stream will automatically call `#write`.
  - For most cases where input isn't expected to be a stream it would make sense to pre-read from the stream & pass input like the old API. Perhaps the stream input API could be handled by a special method e.g. (`env[:ruby_stream_method]`, instead of `env[:ruby_method]`) 
    - `protoc-gen-twirp_ruby` could be updated to generate some different code when the `proto` file indicates the input can be streamed.
